### PR TITLE
Fix shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Replace the values in **.env.example** with your values and rename this file to 
 Get up and running with `make deploy`:
 
 ```shell
-$ git clone https://github.com/toddbirchard/flasklogin-tutorial.git
-$ cd flasklogin-tutorial
-$ make deploy
+git clone https://github.com/toddbirchard/flasklogin-tutorial.git
+cd flasklogin-tutorial
+make deploy
 ``` 
 
 -----


### PR DESCRIPTION
The copy & paste function get the $ when you use it.

Minor error for those users without a lot of knowledge.